### PR TITLE
test: ensure .git directory ignored when listing repo files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,4 @@ target-version = ["py311"]
 
 [tool.ruff]
 target-version = "py311"
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/tests/test_list_files.py
+++ b/tests/test_list_files.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import pytest
+
+from list_files import list_repository_files
+
+
+@pytest.fixture
+def sample_repo(tmp_path: Path) -> Path:
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "ignored.txt").write_text("x")
+    (tmp_path / "dir").mkdir()
+    (tmp_path / "dir" / "b.txt").write_text("b")
+    return tmp_path
+
+
+def test_lists_sorted_relative_paths(sample_repo: Path) -> None:
+    files = list_repository_files(sample_repo)
+    assert files == ["a.txt", "dir/b.txt"]
+
+
+def test_defaults_to_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "one").write_text("1")
+    (tmp_path / "two").write_text("2")
+    monkeypatch.chdir(tmp_path)
+    assert sorted(list_repository_files()) == ["one", "two"]


### PR DESCRIPTION
## Summary
- verify `list_repository_files` skips `.git` contents and defaults to the current working directory
- configure pytest via `pytest.ini` to include project root on `PYTHONPATH` and target the `tests` directory

## Testing
- [ ] `ruff .` (fails: unrecognized subcommand)
- [x] `ruff check .`
- [x] `black --check .`
- [x] `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f2dbf1ef88326bc21363ef6e638de