### PR TITLE
feat: expose list_repository_files for reuse

### DIFF
--- a/list_files.py
+++ b/list_files.py
@@ -28,10 +28,18 @@ def list_repository_files(path: Path | None = None) -> list[str]:
 
 def main():
     """Main function to list repository files."""
+    repo_arg = sys.argv[1] if len(sys.argv) > 1 else None
+    repo_path: Path | None = None
+    if repo_arg is not None:
+        try:
+            repo_path = Path(repo_arg)
+        except OSError as exc:
+            print(f"Invalid path {repo_arg!r}: {exc}", file=sys.stderr)
+            sys.exit(1)
+        if not repo_path.exists():
+            print(f"Path does not exist: {repo_arg}", file=sys.stderr)
+            sys.exit(1)
     try:
-        # Get repository path from command line or use current directory
-        repo_path = Path(sys.argv[1]) if len(sys.argv) > 1 else None
-
         target = repo_path or Path.cwd()
         print(f"Listing files in repository: {target.resolve()}")
         print("-" * 50)

--- a/list_files.py
+++ b/list_files.py
@@ -1,40 +1,27 @@
 #!/usr/bin/env python3
-"""
-AI Dataset Health ZOS - File Listing Tool
+"""AI Dataset Health ZOS - File Listing Tool.
 
 This script lists files in the repository for the AI dataset health scoring tool
 for IBM z/OS via z/0SMF.
 """
 
-import os
-import sys
 from pathlib import Path
+import sys
 
 
-def list_repository_files(repo_path="."):
-    """
-    List all files in the repository.
+def list_repository_files(path: Path | None = None) -> list[str]:
+    """Return sorted relative file paths within *path*, ignoring ``.git``.
 
     Args:
-        repo_path (str): Path to the repository (default: current directory)
-
-    Returns:
-        list: List of file paths relative to the repository root
+        path: Repository root. Defaults to :func:`pathlib.Path.cwd`.
     """
-    repo_path = Path(repo_path).resolve()
-    files = []
+    if path is None:
+        path = Path.cwd()
 
-    # Walk through all files in the repository
-    for root, dirs, filenames in os.walk(repo_path):
-        # Skip .git directory
-        if ".git" in dirs:
-            dirs.remove(".git")
-
-        for filename in filenames:
-            file_path = Path(root) / filename
-            # Get path relative to repository root
-            relative_path = file_path.relative_to(repo_path)
-            files.append(str(relative_path))
+    files: list[str] = []
+    for p in path.rglob("*"):
+        if p.is_file() and ".git" not in p.parts:
+            files.append(str(p.relative_to(path)))
 
     return sorted(files)
 
@@ -43,9 +30,10 @@ def main():
     """Main function to list repository files."""
     try:
         # Get repository path from command line or use current directory
-        repo_path = sys.argv[1] if len(sys.argv) > 1 else "."
+        repo_path = Path(sys.argv[1]) if len(sys.argv) > 1 else None
 
-        print(f"Listing files in repository: {Path(repo_path).resolve()}")
+        target = repo_path or Path.cwd()
+        print(f"Listing files in repository: {target.resolve()}")
         print("-" * 50)
 
         files = list_repository_files(repo_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,4 @@ target-version = ["py311"]
 
 [tool.ruff]
 target-version = "py311"
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/tests/test_list_files.py
+++ b/tests/test_list_files.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import pytest
+
+from list_files import list_repository_files
+
+
+@pytest.fixture
+def sample_repo(tmp_path: Path) -> Path:
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "ignored.txt").write_text("x")
+    (tmp_path / "dir").mkdir()
+    (tmp_path / "dir" / "b.txt").write_text("b")
+    return tmp_path
+
+
+def test_lists_sorted_relative_paths(sample_repo: Path) -> None:
+    files = list_repository_files(sample_repo)
+    assert files == ["a.txt", "dir/b.txt"]
+
+
+def test_defaults_to_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "one").write_text("1")
+    (tmp_path / "two").write_text("2")
+    monkeypatch.chdir(tmp_path)
+    assert sorted(list_repository_files()) == ["one", "two"]


### PR DESCRIPTION
## Summary
- expose `list_repository_files` utility that returns sorted file paths and ignores `.git`
- verify `.git` entries are skipped and current working directory is used when no path is given
- configure pytest to search `tests` and include project root on `PYTHONPATH`

## Testing
- [ ] `ruff .` (fails: unrecognized subcommand)
- [x] `ruff check .`
- [x] `black --check .`
- [x] `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f2dbf1ef88326bc21363ef6e638de