### PR TITLE
feat: options for list_files (include/exclude, max_depth, hidden)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ python3 list_files.py /path/to/repository
 ./list_files.py
 ```
 
+### Options
+
+```python
+from list_files import list_repository_files
+
+# Include only text files
+list_repository_files(include=['**/*.txt'])
+
+# Exclude test directories
+list_repository_files(exclude=['tests/**'])
+
+# Limit search depth
+list_repository_files(max_depth=1)
+
+# Include hidden files
+list_repository_files(include_hidden=True)
+```
+
+
 ## Files
 
 - `list_files.py` - Tool to list all files in the repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ target-version = ["py311"]
 
 [tool.ruff]
 target-version = "py311"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/tests/test_list_files.py
+++ b/tests/test_list_files.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+import pytest
+
+from list_files import list_repository_files
+
+
+@pytest.fixture
+def sample_repo(tmp_path: Path) -> Path:
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "ignored.txt").write_text("x")
+    (tmp_path / "dir").mkdir()
+    (tmp_path / "dir" / "b.txt").write_text("b")
+    return tmp_path
+
+
+def test_lists_sorted_relative_paths(sample_repo: Path) -> None:
+    files = list_repository_files(sample_repo)
+    assert files == ["a.txt", "dir/b.txt"]
+
+
+def test_defaults_to_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "one").write_text("1")
+    (tmp_path / "two").write_text("2")
+    monkeypatch.chdir(tmp_path)
+    assert sorted(list_repository_files()) == ["one", "two"]
+
+
+def test_include_glob_only_txt(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / "b.md").write_text("b")
+    (tmp_path / "dir").mkdir()
+    (tmp_path / "dir" / "c.txt").write_text("c")
+    result = list_repository_files(tmp_path, include=["**/*.txt"])
+    assert result == ["a.txt", "dir/c.txt"]
+
+
+def test_exclude_dir_pattern(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / "b.md").write_text("b")
+    (tmp_path / "dir").mkdir()
+    (tmp_path / "dir" / "c.txt").write_text("c")
+    (tmp_path / "dir" / "skip").mkdir()
+    (tmp_path / "dir" / "skip" / "me.log").write_text("x")
+    result = list_repository_files(tmp_path, exclude=["dir/**"])
+    assert result == ["a.txt", "b.md"]
+
+
+def test_max_depth_limits_walk(tmp_path: Path) -> None:
+    (tmp_path / "top.txt").write_text("t")
+    (tmp_path / "d1").mkdir()
+    (tmp_path / "d1" / "a.txt").write_text("a")
+    (tmp_path / "d1" / "d2").mkdir()
+    (tmp_path / "d1" / "d2" / "b.txt").write_text("b")
+    result = list_repository_files(tmp_path, max_depth=1)
+    assert result == ["d1/a.txt", "top.txt"]
+
+
+def test_hidden_files_default_and_opt_in(tmp_path: Path) -> None:
+    (tmp_path / ".secret").write_text("s")
+    (tmp_path / ".hidden").mkdir()
+    (tmp_path / ".hidden" / "file.txt").write_text("h")
+    (tmp_path / "visible.txt").write_text("v")
+    assert list_repository_files(tmp_path) == ["visible.txt"]
+    assert list_repository_files(tmp_path, include_hidden=True) == [
+        ".hidden/file.txt",
+        ".secret",
+        "visible.txt",
+    ]


### PR DESCRIPTION
## Summary
- expand `list_repository_files` with optional include/exclude glob patterns, depth limiting, and hidden file control
- document usage of the new options and test include/exclude, max depth, and hidden file handling

## Testing
- [ ] `ruff .` (fails: unrecognized subcommand)
- [x] `ruff check .`
- [x] `black --check .`
- [x] `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f2dbf1ef88326bc21363ef6e638de