### PR TITLE
feat: options for list_files (include/exclude, max_depth, hidden)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ python3 list_files.py /path/to/repository
 ./list_files.py
 ```
 
+### Options
+
+```python
+from list_files import list_repository_files
+
+# Include only text files
+list_repository_files(include=['**/*.txt'])
+
+# Exclude test directories
+list_repository_files(exclude=['tests/**'])
+
+# Limit search depth
+list_repository_files(max_depth=1)
+
+# Include hidden files
+list_repository_files(include_hidden=True)
+```
+
+
 ## Files
 
 - `list_files.py` - Tool to list all files in the repository

--- a/list_files.py
+++ b/list_files.py
@@ -1,54 +1,112 @@
 #!/usr/bin/env python3
-"""
-AI Dataset Health ZOS - File Listing Tool
+"""AI Dataset Health ZOS - File Listing Tool.
 
 This script lists files in the repository for the AI dataset health scoring tool
 for IBM z/OS via z/0SMF.
 """
 
+from pathlib import Path, PurePosixPath
 import os
 import sys
-from pathlib import Path
 
 
-def list_repository_files(repo_path="."):
-    """
-    List all files in the repository.
+def list_repository_files(
+    repo_path: str | Path = ".",
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+    max_depth: int | None = None,
+    include_hidden: bool = False,
+) -> list[str]:
+    """Return sorted relative file paths within ``repo_path``.
 
     Args:
-        repo_path (str): Path to the repository (default: current directory)
-
-    Returns:
-        list: List of file paths relative to the repository root
+        repo_path: Repository root. Defaults to current working directory.
+        include: Glob patterns to include. Keep files matching any pattern.
+        exclude: Glob patterns to exclude. ``".git/**"`` is always excluded.
+        max_depth: Maximum directory depth to traverse relative to ``repo_path``.
+        include_hidden: Include files and directories starting with ``.``.
     """
-    repo_path = Path(repo_path).resolve()
-    files = []
+    root = Path(repo_path).resolve()
+    if not root.exists():
+        return []
 
-    # Walk through all files in the repository
-    for root, dirs, filenames in os.walk(repo_path):
-        # Skip .git directory
-        if ".git" in dirs:
-            dirs.remove(".git")
+    if max_depth is not None and max_depth < 0:
+        max_depth = None
+
+    base_exclude = [".git/**"]
+    patterns_exclude = base_exclude + (exclude or [])
+
+    def _matches_pattern(
+        posix_path: PurePosixPath, rel_path: str, pattern: str
+    ) -> bool:
+        """Return True if ``pattern`` matches ``rel_path``."""
+        if pattern.endswith("/**"):
+            prefix = pattern[:-3]
+            if rel_path == prefix or rel_path.startswith(f"{prefix}/"):
+                return True
+        if posix_path.match(pattern):
+            return True
+        if pattern.startswith("**/") and posix_path.match(pattern[3:]):
+            return True
+        return False
+
+    def _match_any(rel_path: str, patterns: list[str]) -> bool:
+        posix_path = PurePosixPath(rel_path)
+        for pattern in patterns:
+            if _matches_pattern(posix_path, rel_path, pattern):
+                return True
+        return False
+
+    files: list[str] = []
+    root_depth = len(root.parts)
+    for dirpath, dirnames, filenames in os.walk(root):
+        current = Path(dirpath)
+        rel_depth = len(current.parts) - root_depth
+        if max_depth is not None and rel_depth >= max_depth:
+            dirnames[:] = []
+        if include_hidden:
+            dirnames[:] = [d for d in dirnames if d != ".git"]
+        else:
+            dirnames[:] = [d for d in dirnames if not d.startswith(".")]
 
         for filename in filenames:
-            file_path = Path(root) / filename
-            # Get path relative to repository root
-            relative_path = file_path.relative_to(repo_path)
-            files.append(str(relative_path))
+            if not include_hidden and filename.startswith("."):
+                continue
+            path = Path(dirpath, filename)
+            if path.is_symlink():
+                try:
+                    path.resolve().relative_to(root)
+                except ValueError:
+                    continue
+            rel_path = path.relative_to(root).as_posix()
+            if include and not _match_any(rel_path, include):
+                continue
+            if _match_any(rel_path, patterns_exclude):
+                continue
+            files.append(rel_path)
 
     return sorted(files)
 
 
 def main():
     """Main function to list repository files."""
+    repo_arg = sys.argv[1] if len(sys.argv) > 1 else None
+    repo_path: Path | None = None
+    if repo_arg is not None:
+        repo_path = Path(repo_arg)
+        try:
+            if not repo_path.exists():
+                print(f"Path does not exist: {repo_arg}", file=sys.stderr)
+                sys.exit(1)
+        except OSError as exc:
+            print(f"Cannot access path {repo_arg!r}: {exc}", file=sys.stderr)
+            sys.exit(1)
     try:
-        # Get repository path from command line or use current directory
-        repo_path = sys.argv[1] if len(sys.argv) > 1 else "."
-
-        print(f"Listing files in repository: {Path(repo_path).resolve()}")
+        target = repo_path or Path.cwd()
+        print(f"Listing files in repository: {target.resolve()}")
         print("-" * 50)
 
-        files = list_repository_files(repo_path)
+        files = list_repository_files(target)
 
         if files:
             for i, file_path in enumerate(files, 1):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,6 @@ target-version = ["py311"]
 
 [tool.ruff]
 target-version = "py311"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/tests/test_list_files.py
+++ b/tests/test_list_files.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+import pytest
+
+from list_files import list_repository_files
+
+
+@pytest.fixture
+def sample_repo(tmp_path: Path) -> Path:
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "ignored.txt").write_text("x")
+    (tmp_path / "dir").mkdir()
+    (tmp_path / "dir" / "b.txt").write_text("b")
+    return tmp_path
+
+
+def test_lists_sorted_relative_paths(sample_repo: Path) -> None:
+    files = list_repository_files(sample_repo)
+    assert files == ["a.txt", "dir/b.txt"]
+
+
+def test_defaults_to_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / "one").write_text("1")
+    (tmp_path / "two").write_text("2")
+    monkeypatch.chdir(tmp_path)
+    assert sorted(list_repository_files()) == ["one", "two"]
+
+
+def test_include_glob_only_txt(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / "b.md").write_text("b")
+    (tmp_path / "dir").mkdir()
+    (tmp_path / "dir" / "c.txt").write_text("c")
+    result = list_repository_files(tmp_path, include=["**/*.txt"])
+    assert result == ["a.txt", "dir/c.txt"]
+
+
+def test_exclude_dir_pattern(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("a")
+    (tmp_path / "b.md").write_text("b")
+    (tmp_path / "dir").mkdir()
+    (tmp_path / "dir" / "c.txt").write_text("c")
+    (tmp_path / "dir" / "skip").mkdir()
+    (tmp_path / "dir" / "skip" / "me.log").write_text("x")
+    result = list_repository_files(tmp_path, exclude=["dir/**"])
+    assert result == ["a.txt", "b.md"]
+
+
+def test_max_depth_limits_walk(tmp_path: Path) -> None:
+    (tmp_path / "top.txt").write_text("t")
+    (tmp_path / "d1").mkdir()
+    (tmp_path / "d1" / "a.txt").write_text("a")
+    (tmp_path / "d1" / "d2").mkdir()
+    (tmp_path / "d1" / "d2" / "b.txt").write_text("b")
+    result = list_repository_files(tmp_path, max_depth=1)
+    assert result == ["d1/a.txt", "top.txt"]
+
+
+def test_hidden_files_default_and_opt_in(tmp_path: Path) -> None:
+    (tmp_path / ".secret").write_text("s")
+    (tmp_path / ".hidden").mkdir()
+    (tmp_path / ".hidden" / "file.txt").write_text("h")
+    (tmp_path / "visible.txt").write_text("v")
+    assert list_repository_files(tmp_path) == ["visible.txt"]
+    assert list_repository_files(tmp_path, include_hidden=True) == [
+        ".hidden/file.txt",
+        ".secret",
+        "visible.txt",
+    ]


### PR DESCRIPTION
## Summary
- expand `list_repository_files` with optional include/exclude glob patterns, depth limiting, and hidden file control
- document usage of the new options and test include/exclude, max depth, and hidden file handling
- fix glob prefix matching to satisfy Ruff

## Testing
- [ ] `ruff .` (fails: unrecognized subcommand '.')
- [x] `ruff check .`
- [x] `black --check .`
- [x] `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f2dbf1ef88326bc21363ef6e638de