### PR TITLE
Fix test imports and improve file listing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Run tests (if present)
         if: ${{ hashFiles('tests/**/*.py') != '' }}
+        env:
+          PYTHONPATH: .
         run: |
           pytest -q --junitxml=test-results.xml --cov=list_files --cov-report=term-missing
 

--- a/list_files.py
+++ b/list_files.py
@@ -5,25 +5,94 @@ This script lists files in the repository for the AI dataset health scoring tool
 for IBM z/OS via z/0SMF.
 """
 
+from __future__ import annotations
+
+import os
 from pathlib import Path
 import sys
 
 
-def list_repository_files(path: Path | None = None) -> list[str]:
-    """Return sorted relative file paths within *path*, ignoring ``.git``.
+def list_repository_files(
+    repo_path: str | Path = ".",
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+    max_depth: int | None = None,
+    include_hidden: bool = False,
+) -> list[str]:
+    """List files under `repo_path` as sorted, relative POSIX paths, with filtering.
 
-    Args:
-        path: Repository root. Defaults to :func:`pathlib.Path.cwd`.
+    - `include`: keep only paths matching ANY glob (Path.match on relative POSIX).
+    - `exclude`: drop paths matching ANY glob; wins over include.
+    - Always excludes .git/**.
+    - `max_depth`: 0 = only files at root; 1 = root and one level below; etc.
+    - `include_hidden`: if False, skip entries starting with '.' (files/dirs).
     """
-    if path is None:
-        path = Path.cwd()
+    root = Path(repo_path).resolve()
+    if not root.exists():
+        return []
 
-    files: list[str] = []
-    for p in path.rglob("*"):
-        if p.is_file() and ".git" not in p.parts:
-            files.append(str(p.relative_to(path)))
+    # Normalize args
+    base_exclude = {".git/**"}
+    inc = [p for p in (include or []) if p] or None
+    exc = list(base_exclude | set(exclude or []))
+    depth_limit = None if (max_depth is None or max_depth < 0) else int(max_depth)
 
-    return sorted(files)
+    def is_hidden_part(p: Path) -> bool:
+        # Any component that starts with '.' means "hidden"
+        return any(part.startswith(".") for part in p.parts)
+
+    out: list[str] = []
+
+    # Use os.walk to prune traversal early (depth + excludes + hidden dirs)
+    for dirpath, dirnames, filenames in os.walk(root):
+        dir_path = Path(dirpath)
+        rel_dir = dir_path.relative_to(root)
+
+        # Prune hidden dirs if include_hidden is False
+        if not include_hidden:
+            dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+
+        # Prune by depth
+        if depth_limit is not None:
+            current_depth = len(rel_dir.parts)  # 0 at root
+            # If we're already deeper than depth_limit, stop descending
+            if current_depth >= depth_limit:
+                dirnames[:] = []
+
+        # Prune excludes on directories (avoid descending into excluded trees)
+        # Apply patterns on POSIX rel path with a trailing slash for dirs
+        pruned = []
+        for d in dirnames:
+            rel_d = (rel_dir / d).as_posix()
+            # if excluded by any pattern like "dir/**", skip entering it
+            if any(
+                Path(rel_d).match(p.rstrip("/")) or Path(rel_d + "/").match(p)
+                for p in exc
+            ):
+                continue
+            pruned.append(d)
+        dirnames[:] = pruned
+
+        # Files in this directory
+        for fn in filenames:
+            file_path = dir_path / fn
+            rel = file_path.relative_to(root).as_posix()
+
+            if not include_hidden and is_hidden_part(Path(rel)):
+                continue
+
+            # include filter (if provided)
+            if inc is not None and not any(Path(rel).match(p) for p in inc):
+                continue
+
+            # exclude filter (wins)
+            if any(Path(rel).match(p) for p in exc):
+                continue
+
+            out.append(rel)
+
+    out.sort()
+    return out
 
 
 def main():


### PR DESCRIPTION
## Summary
- ensure CI tests import from repository root by setting `PYTHONPATH`
- replace `list_repository_files` with sorted POSIX paths, include/exclude filters, and depth pruning

## Testing
- [x] `ruff check .`
- [x] `black --check .`
- [x] `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0d128a6508326b12fe1c098944e51