### PR TITLE
Add mypy and coverage checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff black pytest pytest-cov
+          pip install ruff black pytest pytest-cov mypy
 
       - name: Lint with ruff
         run: ruff check . --output-format=github
@@ -33,12 +33,15 @@ jobs:
       - name: Check formatting with black
         run: black --check .
 
+      - name: Run mypy
+        run: mypy .
+
       - name: Run tests (if present)
         if: ${{ hashFiles('tests/**/*.py') != '' }}
         env:
           PYTHONPATH: .
         run: |
-          pytest -q --junitxml=test-results.xml --cov=list_files --cov-report=term-missing
+          pytest -q --junitxml=test-results.xml --cov=./ --cov-report=term-missing --cov-fail-under=80
 
       - name: Upload pytest results
         if: ${{ always() && hashFiles('tests/**/*.py') != '' }}

--- a/list_files.py
+++ b/list_files.py
@@ -95,9 +95,9 @@ def list_repository_files(
     return out
 
 
-def main():
+def main() -> None:
     """Main function to list repository files."""
-    repo_arg = sys.argv[1] if len(sys.argv) > 1 else None
+    repo_arg: str | None = sys.argv[1] if len(sys.argv) > 1 else None
     repo_path: Path | None = None
     if repo_arg is not None:
         repo_path = Path(repo_arg)
@@ -113,7 +113,7 @@ def main():
         print(f"Listing files in repository: {target.resolve()}")
         print("-" * 50)
 
-        files = list_repository_files(repo_path)
+        files: list[str] = list_repository_files(target)
 
         if files:
             for i, file_path in enumerate(files, 1):
@@ -122,8 +122,8 @@ def main():
         else:
             print("No files found in the repository.")
 
-    except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,10 @@ target-version = "py311"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+
+[tool.mypy]
+python_version = "3.13"
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+pretty = true


### PR DESCRIPTION
## Summary
- add explicit typing for CLI entry point
- enable strict mypy configuration for Python 3.13
- run mypy and enforce >=80% coverage in CI

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=. pytest -q`

## PR Checklist
- [x] `ruff .`
- [x] `black --check .`
- [x] `mypy .`
- [x] `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a17cf45afc832681a89c88292f709e