### PR TITLE
feat(cli): add health flag and type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,26 +22,29 @@ jobs:
             pyproject.toml
             requirements*.txt
 
-      - name: Install dependencies
+      - name: Install tools
         run: |
           python -m pip install --upgrade pip
-          pip install ruff black pytest pytest-cov
+          pip install ruff black mypy pytest pytest-cov
 
-      - name: Lint with ruff
+      - name: Ruff check
         run: ruff check . --output-format=github
 
-      - name: Check formatting with black
+      - name: Black check
         run: black --check .
 
-      - name: Run tests (if present)
-        if: ${{ hashFiles('tests/**/*.py') != '' }}
+      - name: Mypy
+        run: mypy .
+
+      - name: Pytest (coverage ≥80)
         env:
           PYTHONPATH: .
         run: |
-          pytest -q --junitxml=test-results.xml --cov=list_files --cov-report=term-missing
+          pytest -q --junitxml=test-results.xml \
+            --cov=list_files --cov-report=term-missing --cov-fail-under=80
 
       - name: Upload pytest results
-        if: ${{ always() && hashFiles('tests/**/*.py') != '' }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: pytest-results

--- a/health.py
+++ b/health.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import os
+
+
+@dataclass(frozen=True)
+class HealthReport:
+    total_files: int
+    zero_byte_files: list[str]
+    score: int
+
+
+def compute_health(root: Path) -> HealthReport:
+    """Compute basic health metrics for files under ``root``.
+
+    Files within any ``.git`` directory are ignored. Paths are returned as
+    sorted, relative POSIX strings.
+    """
+    root = root.resolve()
+    files: list[str] = []
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Skip .git directories
+        dirnames[:] = [d for d in dirnames if d != ".git"]
+        dir_path = Path(dirpath)
+        for name in filenames:
+            rel = (dir_path / name).relative_to(root).as_posix()
+            files.append(rel)
+
+    files.sort()
+    zero_byte_files = [p for p in files if (root / p).stat().st_size == 0]
+    total_files = len(files)
+    score = (
+        0 if total_files == 0 else 100 - round(100 * len(zero_byte_files) / total_files)
+    )
+    return HealthReport(total_files, zero_byte_files, score)

--- a/list_files.py
+++ b/list_files.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
-"""AI Dataset Health ZOS - File Listing Tool.
+"""
+AI Dataset Health z/OS — repository file utilities and CLI.
 
-This script lists files in the repository for the AI dataset health scoring tool
-for IBM z/OS via z/0SMF.
+- list_repository_files(): list files (relative to repo root), skipping .git/
+- CLI: by default prints files; with --health prints an "empty-file" health score
 """
 
 from __future__ import annotations
 
+import argparse
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
+
+from health import HealthReport, compute_health
 
 
 def list_repository_files(
@@ -19,52 +23,43 @@ def list_repository_files(
     max_depth: int | None = None,
     include_hidden: bool = False,
 ) -> list[str]:
-    """List files under `repo_path` as sorted, relative POSIX paths, with filtering.
+    """List files under ``repo_path`` as sorted, relative POSIX paths, with filtering.
 
-    - `include`: keep only paths matching ANY glob (Path.match on relative POSIX).
-    - `exclude`: drop paths matching ANY glob; wins over include.
+    - ``include``: keep only paths matching ANY glob (Path.match on relative POSIX).
+    - ``exclude``: drop paths matching ANY glob; wins over include.
     - Always excludes .git/**.
-    - `max_depth`: 0 = only files at root; 1 = root and one level below; etc.
-    - `include_hidden`: if False, skip entries starting with '.' (files/dirs).
+    - ``max_depth``: 0 = only files at root; 1 = root and one level below; etc.
+    - ``include_hidden``: if False, skip entries starting with '.' (files/dirs).
     """
     root = Path(repo_path).resolve()
     if not root.exists():
         return []
 
-    # Normalize args
     base_exclude = {".git/**"}
     inc = [p for p in (include or []) if p] or None
     exc = list(base_exclude | set(exclude or []))
     depth_limit = None if (max_depth is None or max_depth < 0) else int(max_depth)
 
     def is_hidden_part(p: Path) -> bool:
-        # Any component that starts with '.' means "hidden"
         return any(part.startswith(".") for part in p.parts)
 
     out: list[str] = []
 
-    # Use os.walk to prune traversal early (depth + excludes + hidden dirs)
     for dirpath, dirnames, filenames in os.walk(root):
         dir_path = Path(dirpath)
         rel_dir = dir_path.relative_to(root)
 
-        # Prune hidden dirs if include_hidden is False
         if not include_hidden:
             dirnames[:] = [d for d in dirnames if not d.startswith(".")]
 
-        # Prune by depth
         if depth_limit is not None:
-            current_depth = len(rel_dir.parts)  # 0 at root
-            # If we're already deeper than depth_limit, stop descending
+            current_depth = len(rel_dir.parts)
             if current_depth >= depth_limit:
                 dirnames[:] = []
 
-        # Prune excludes on directories (avoid descending into excluded trees)
-        # Apply patterns on POSIX rel path with a trailing slash for dirs
         pruned = []
         for d in dirnames:
             rel_d = (rel_dir / d).as_posix()
-            # if excluded by any pattern like "dir/**", skip entering it
             if any(
                 Path(rel_d).match(p.rstrip("/")) or Path(rel_d + "/").match(p)
                 for p in exc
@@ -73,7 +68,6 @@ def list_repository_files(
             pruned.append(d)
         dirnames[:] = pruned
 
-        # Files in this directory
         for fn in filenames:
             file_path = dir_path / fn
             rel = file_path.relative_to(root).as_posix()
@@ -81,11 +75,9 @@ def list_repository_files(
             if not include_hidden and is_hidden_part(Path(rel)):
                 continue
 
-            # include filter (if provided)
             if inc is not None and not any(Path(rel).match(p) for p in inc):
                 continue
 
-            # exclude filter (wins)
             if any(Path(rel).match(p) for p in exc):
                 continue
 
@@ -95,37 +87,61 @@ def list_repository_files(
     return out
 
 
-def main():
-    """Main function to list repository files."""
-    repo_arg = sys.argv[1] if len(sys.argv) > 1 else None
-    repo_path: Path | None = None
-    if repo_arg is not None:
-        repo_path = Path(repo_arg)
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="List repository files (skips .git); optionally report health."
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=None,
+        help="Repository root to scan (defaults to current working directory).",
+    )
+    parser.add_argument(
+        "--health",
+        action="store_true",
+        help="Report health score (based on empty-file count) instead of listing.",
+    )
+
+    args = parser.parse_args(argv)
+
+    repo_path = Path(args.path) if args.path is not None else None
+    if repo_path is not None:
         try:
             if not repo_path.exists():
-                print(f"Path does not exist: {repo_arg}", file=sys.stderr)
-                sys.exit(1)
+                print(f"Path does not exist: {args.path}", file=sys.stderr)
+                raise SystemExit(1)
         except OSError as exc:
-            print(f"Cannot access path {repo_arg!r}: {exc}", file=sys.stderr)
-            sys.exit(1)
-    try:
-        target = repo_path or Path.cwd()
-        print(f"Listing files in repository: {target.resolve()}")
-        print("-" * 50)
+            print(f"Cannot access path {args.path!r}: {exc}", file=sys.stderr)
+            raise SystemExit(1)
 
-        files = list_repository_files(repo_path)
+    target = repo_path or Path.cwd()
 
-        if files:
-            for i, file_path in enumerate(files, 1):
-                print(f"{i:2}. {file_path}")
-            print(f"\nTotal files: {len(files)}")
-        else:
-            print("No files found in the repository.")
+    if args.health:
+        report: HealthReport = compute_health(target)
+        score = 100.0 if report.total_files == 0 else float(report.score)
+        print(f"Health score: {score:.1f}%")
+        print(f"Zero-byte files: {len(report.zero_byte_files)}")
+        print(f"Total files: {report.total_files}")
+        return 0
 
-    except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
+    print(f"Listing files in repository: {target.resolve()}")
+    print("-" * 50)
+
+    files: list[str] = list_repository_files(repo_path or Path.cwd())
+
+    if files:
+        for i, file_path in enumerate(files, 1):
+            print(f"{i:2}. {file_path}")
+        print(f"\nTotal files: {len(files)}")
+    else:
+        print("No files found in the repository.")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # noqa: BLE001 - keep CLI robust
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,10 @@ target-version = "py311"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+
+[tool.mypy]
+python_version = "3.13"
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+pretty = true

--- a/tests/test_cli_health.py
+++ b/tests/test_cli_health.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import pytest
+
+from list_files import main
+
+
+def test_cli_health_reports(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (tmp_path / "a.txt").write_text("x")
+    (tmp_path / "empty.bin").touch()
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "ignored.txt").write_text("ignore")
+    main(["--health", str(tmp_path)])
+    captured = capsys.readouterr()
+    assert captured.out.strip().splitlines() == [
+        "Health score: 50.0%",
+        "Zero-byte files: 1",
+        "Total files: 2",
+    ]
+    assert "Listing files in repository" not in captured.out
+
+
+def test_cli_health_empty(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    main(["--health", str(tmp_path)])
+    captured = capsys.readouterr()
+    assert captured.out.strip().splitlines() == [
+        "Health score: 100.0%",
+        "Zero-byte files: 0",
+        "Total files: 0",
+    ]
+    assert "Listing files in repository" not in captured.out

--- a/tests/test_health_basic.py
+++ b/tests/test_health_basic.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from health import compute_health
+
+
+def test_compute_health_reports_zero_byte(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("x")
+    (tmp_path / "empty.bin").touch()
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "ignored.txt").touch()
+
+    report = compute_health(tmp_path)
+
+    assert report.total_files == 2
+    assert report.zero_byte_files == ["empty.bin"]
+    assert report.score == 50
+
+
+def test_compute_health_empty_directory(tmp_path: Path) -> None:
+    report = compute_health(tmp_path)
+
+    assert report.total_files == 0
+    assert report.zero_byte_files == []
+    assert report.score == 0

--- a/tests/test_list_files.py
+++ b/tests/test_list_files.py
@@ -1,7 +1,8 @@
 from pathlib import Path
+import sys
 import pytest
 
-from list_files import list_repository_files
+from list_files import list_repository_files, main
 
 
 @pytest.fixture
@@ -24,3 +25,47 @@ def test_defaults_to_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     (tmp_path / "two").write_text("2")
     monkeypatch.chdir(tmp_path)
     assert sorted(list_repository_files()) == ["one", "two"]
+
+
+def test_nonexistent_repo_returns_empty(tmp_path: Path) -> None:
+    missing = tmp_path / "missing"
+    assert list_repository_files(missing) == []
+
+
+def test_filters_and_depth(tmp_path: Path) -> None:
+    (tmp_path / "keep.py").write_text("k")
+    (tmp_path / "skip.log").write_text("s")
+    (tmp_path / ".hidden").write_text("h")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "keep.txt").write_text("k")
+    (tmp_path / "sub" / "skip.md").write_text("s")
+    files = list_repository_files(
+        tmp_path,
+        include=["*.py", "sub/*"],
+        exclude=["*.log", "sub/*.md"],
+        max_depth=2,
+    )
+    assert files == ["keep.py", "sub/keep.txt"]
+
+
+def test_main_success(
+    sample_repo: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["list_files.py", str(sample_repo)])
+    main()
+    out = capsys.readouterr().out
+    assert "Listing files in repository" in out
+    assert "Total files: 2" in out
+
+
+def test_main_missing_path(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["list_files.py", "does-not-exist"])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1
+    err = capsys.readouterr().err
+    assert "Path does not exist" in err


### PR DESCRIPTION
## Summary
- integrate empty-file health flag into file listing CLI with type hints and missing-path error handling
- expand list-files tests for filtering, depth, and path validation

## Testing
- [x] `ruff check .`
- [x] `black --check .`
- [x] `mypy .`
- [x] `PYTHONPATH=. pytest -q`

## PR Checklist
- [x] `ruff .`
- [x] `black --check .`
- [x] `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a17cf45afc832681a89c88292f709e