### PR TITLE
ci: keep mypy+coverage; add health smoke step; fix .git exclusion; docs: quick run snippet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,30 +22,44 @@ jobs:
             pyproject.toml
             requirements*.txt
 
-      - name: Install dependencies
+      - name: Install tools
         run: |
           python -m pip install --upgrade pip
-          pip install ruff black pytest pytest-cov mypy
+          pip install ruff black mypy pytest pytest-cov
 
-      - name: Lint with ruff
+      - name: Ruff check
         run: ruff check . --output-format=github
 
-      - name: Check formatting with black
+      - name: Black check
         run: black --check .
 
-      - name: Run mypy
+      - name: Mypy
         run: mypy .
 
-      - name: Run tests (if present)
-        if: ${{ hashFiles('tests/**/*.py') != '' }}
+      - name: Pytest (coverage ≥80)
         env:
           PYTHONPATH: .
         run: |
-          pytest -q --junitxml=test-results.xml --cov=./ --cov-report=term-missing --cov-fail-under=80
+          pytest -q --junitxml=test-results.xml \
+            --cov=./ --cov-report=term-missing --cov-fail-under=80
 
       - name: Upload pytest results
-        if: ${{ always() && hashFiles('tests/**/*.py') != '' }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: pytest-results
           path: test-results.xml
+
+      # ---- Task 3: smoke step (non-blocking) ----
+      - name: Health (smoke)
+        env:
+          PYTHONPATH: .
+        run: |
+          python list_files.py --health . | tee health.txt
+
+      - name: Upload health output
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: health-output
+          path: health.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           name: pytest-results
           path: test-results.xml
 
-      # ---- Task 3: smoke step (non-blocking) ----
+      # Smoke step: non-blocking
       - name: Health (smoke)
         env:
           PYTHONPATH: .

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ AI dataset health scoring for IBM z/OS via z/0SMF (Db2-free). ONNX inference run
 
 - **File Listing**: List all files in the repository for analysis and inventory
 
+### Quick start
+
+```bash
+# list files
+python list_files.py .
+
+# run health report (empty-file score)
+python list_files.py --health .
+```
+
 ## Usage
 
 ### List Repository Files

--- a/health.py
+++ b/health.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -13,26 +15,34 @@ class HealthReport:
 
 
 def compute_health(root: Path) -> HealthReport:
-    """Compute basic health metrics for files under ``root``.
-
-    Files within any ``.git`` directory are ignored. Paths are returned as
-    sorted, relative POSIX strings.
     """
-    root = root.resolve()
-    files: list[str] = []
+    Compute a simple empty-file based health score for the given root.
 
-    for dirpath, dirnames, filenames in os.walk(root):
-        # Skip .git directories
-        dirnames[:] = [d for d in dirnames if d != ".git"]
-        dir_path = Path(dirpath)
-        for name in filenames:
-            rel = (dir_path / name).relative_to(root).as_posix()
-            files.append(rel)
+    - total_files counts all regular files under root, excluding anything in .git/
+    - zero_byte_files lists relative POSIX paths whose size is 0
+    - score = 0 if total_files == 0 else 100 - round(100 * len(zero_byte_files) / total_files)
+    """
+    zero_byte_files: list[str] = []
+    total_files = 0
 
-    files.sort()
-    zero_byte_files = [p for p in files if (root / p).stat().st_size == 0]
-    total_files = len(files)
+    for p in root.rglob("*"):
+        if p.is_dir():
+            continue
+        # Exclude files under .git/
+        if any(part == ".git" for part in p.parts):
+            continue
+
+        total_files += 1
+        try:
+            if p.stat().st_size == 0:
+                zero_byte_files.append(p.relative_to(root).as_posix())
+        except OSError as exc:  # pragma: no cover - unusual I/O errors
+            logger.warning("Could not stat file %s: %s", p.relative_to(root), exc)
+
+    zero_byte_files.sort()
     score = (
         0 if total_files == 0 else 100 - round(100 * len(zero_byte_files) / total_files)
     )
-    return HealthReport(total_files, zero_byte_files, score)
+    return HealthReport(
+        total_files=total_files, zero_byte_files=zero_byte_files, score=score
+    )


### PR DESCRIPTION
## Summary
- run `list_files.py --health` in CI and archive the output as an artifact
- keep coverage ≥80% and mypy checks in the workflow
- refine `.git` exclusion when computing the health report
- document quick-start commands for listing files and computing a health score

## Testing
- [ ] `ruff .` *(fails: unrecognized subcommand)*
- [x] `ruff check .`
- [x] `black --check .`
- [x] `mypy .`
- [ ] `PYTHONPATH=. pytest -q --cov=./ --cov-fail-under=80` *(fails: plugin missing)*
- [x] `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a38f401e288326b8fe84b99cfd4c39