### PR TITLE
ci: keep mypy+coverage & health smoke; health.py: prune .git traversal and safe relative path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,30 +22,44 @@ jobs:
             pyproject.toml
             requirements*.txt
 
-      - name: Install dependencies
+      - name: Install tools
         run: |
           python -m pip install --upgrade pip
-          pip install ruff black pytest pytest-cov mypy
+          pip install ruff black mypy pytest pytest-cov
 
-      - name: Lint with ruff
+      - name: Ruff check
         run: ruff check . --output-format=github
 
-      - name: Check formatting with black
+      - name: Black check
         run: black --check .
 
-      - name: Run mypy
+      - name: Mypy
         run: mypy .
 
-      - name: Run tests (if present)
-        if: ${{ hashFiles('tests/**/*.py') != '' }}
+      - name: Pytest (coverage ≥80)
         env:
           PYTHONPATH: .
         run: |
-          pytest -q --junitxml=test-results.xml --cov=./ --cov-report=term-missing --cov-fail-under=80
+          pytest -q --junitxml=test-results.xml \
+            --cov=./ --cov-report=term-missing --cov-fail-under=80
 
       - name: Upload pytest results
-        if: ${{ always() && hashFiles('tests/**/*.py') != '' }}
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: pytest-results
           path: test-results.xml
+
+      # Smoke step: non-blocking
+      - name: Health (smoke)
+        env:
+          PYTHONPATH: .
+        run: |
+          python list_files.py --health . | tee health.txt
+
+      - name: Upload health output
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: health-output
+          path: health.txt

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ AI dataset health scoring for IBM z/OS via z/0SMF (Db2-free). ONNX inference run
 
 - **File Listing**: List all files in the repository for analysis and inventory
 
+### Quick start
+
+```bash
+# list files
+python list_files.py .
+
+# run health report (empty-file score)
+python list_files.py --health .
+```
+
 ## Usage
 
 ### List Repository Files

--- a/health.py
+++ b/health.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -13,26 +16,39 @@ class HealthReport:
 
 
 def compute_health(root: Path) -> HealthReport:
-    """Compute basic health metrics for files under ``root``.
+    """
+    Empty-file based health score for a repository root.
 
-    Files within any ``.git`` directory are ignored. Paths are returned as
-    sorted, relative POSIX strings.
+    Scans all regular files under `root`, skipping any directory named '.git'.
+    Score = 0 if no files, else 100 - round(100 * zero_count / total).
     """
     root = root.resolve()
-    files: list[str] = []
+    zero_byte_files: list[str] = []
+    total_files = 0
 
     for dirpath, dirnames, filenames in os.walk(root):
-        # Skip .git directories
-        dirnames[:] = [d for d in dirnames if d != ".git"]
-        dir_path = Path(dirpath)
-        for name in filenames:
-            rel = (dir_path / name).relative_to(root).as_posix()
-            files.append(rel)
+        # prune .git at traversal level (exact match)
+        if ".git" in dirnames:
+            dirnames.remove(".git")
 
-    files.sort()
-    zero_byte_files = [p for p in files if (root / p).stat().st_size == 0]
-    total_files = len(files)
+        for filename in filenames:
+            p = Path(dirpath) / filename
+            total_files += 1
+            try:
+                if p.stat().st_size == 0:
+                    zero_byte_files.append(p.relative_to(root).as_posix())
+            except OSError as exc:  # pragma: no cover — unusual I/O
+                # compute a safe relative string for logging
+                try:
+                    rel = p.relative_to(root).as_posix()
+                except Exception:
+                    rel = str(p)
+                logger.warning("Could not stat file %s: %s", rel, exc)
+
+    zero_byte_files.sort()
     score = (
         0 if total_files == 0 else 100 - round(100 * len(zero_byte_files) / total_files)
     )
-    return HealthReport(total_files, zero_byte_files, score)
+    return HealthReport(
+        total_files=total_files, zero_byte_files=zero_byte_files, score=score
+    )


### PR DESCRIPTION
## Summary
- run `list_files.py --health` in CI and archive the output as an artifact
- prune `.git` directories during health traversal and log a safe relative path on errors
- keep coverage ≥80% and mypy checks in the workflow

## Testing
- [ ] `ruff .` *(fails: unrecognized subcommand)*
- [x] `ruff check .`
- [x] `black --check .`
- [x] `mypy .`
- [ ] `PYTHONPATH=. pytest -q --cov=./ --cov-fail-under=80` *(fails: plugin missing)*
- [x] `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a38f401e288326b8fe84b99cfd4c39