### PR TITLE
ci: keep mypy+coverage & health smoke; health.py: prune .git traversal and safe relative path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,19 @@ jobs:
           pytest -q --junitxml=test-results.xml \
             --cov=./ --cov-report=term-missing --cov-fail-under=80
 
+      - name: Health smoke
+        run: python list_files.py --health . > health.txt
+
       - name: Upload pytest results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: pytest-results
           path: test-results.xml
+
+      - name: Upload health results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: health-output
+          path: health.txt

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ AI dataset health scoring for IBM z/OS via z/0SMF (Db2-free). ONNX inference run
 
 - **File Listing**: List all files in the repository for analysis and inventory
 
+## Quick start
+
+```bash
+python list_files.py .
+python list_files.py --health .
+```
+
 ## Usage
 
 ### List Repository Files

--- a/health.py
+++ b/health.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -25,19 +26,21 @@ def compute_health(root: Path) -> HealthReport:
     zero_byte_files: list[str] = []
     total_files = 0
 
-    for p in root.rglob("*"):
-        if p.is_dir():
-            continue
-        # Exclude files under .git/
-        if ".git" in p.parts:
-            continue
-
-        total_files += 1
-        try:
-            if p.stat().st_size == 0:
-                zero_byte_files.append(p.relative_to(root).as_posix())
-        except OSError as exc:  # pragma: no cover - unusual I/O errors
-            logger.warning("Could not stat file %s: %s", p.relative_to(root), exc)
+    for dirpath, dirnames, filenames in os.walk(root):
+        if ".git" in dirnames:
+            dirnames.remove(".git")
+        for fn in filenames:
+            p = Path(dirpath) / fn
+            total_files += 1
+            try:
+                if p.stat().st_size == 0:
+                    zero_byte_files.append(p.relative_to(root).as_posix())
+            except OSError as exc:  # pragma: no cover - unusual I/O errors
+                try:
+                    rel = p.relative_to(root).as_posix()
+                except Exception:
+                    rel = str(p)
+                logger.warning("Could not stat file %s: %s", rel, exc)
 
     zero_byte_files.sort()
     score = (


### PR DESCRIPTION
## Summary
- unify CI to run ruff, black, mypy, coverage, and health smoke artifact upload
- prune `.git` directories and use safe relative logging in `health.py`
- document quick start including `--health` flag

## Testing
- [x] `ruff check .`
- [x] `black --check .`
- [x] `mypy .`
- [ ] `PYTHONPATH=. pytest -q --cov=./ --cov-fail-under=80` *(missing `pytest-cov`; ran `PYTHONPATH=. pytest -q`)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b4355d448326877348b54485cae3